### PR TITLE
routerhunter moved to new url

### DIFF
--- a/index.md
+++ b/index.md
@@ -236,7 +236,7 @@ Vulnerability Analysis
 <strong>Author:</strong> Mitch \x90
 <script>commandLine('dnsteal');</script>
 
-* [routerhunter](https://github.com/jh00nbr/Routerhunter-2.0) - The RouterhunterBR is an automated security tool that finds vulnerabilities and performs tests on routers and vulnerable devices on the Internet. The RouterhunterBR was designed to run over the Internet looking for defined ips tracks or random in order to automatically exploit the vulnerability DNSChanger on home routers.
+* [routerhunter](https://github.com/Exploit-install/Routerhunter-2.0) - The RouterhunterBR is an automated security tool that finds vulnerabilities and performs tests on routers and vulnerable devices on the Internet. The RouterhunterBR was designed to run over the Internet looking for defined ips tracks or random in order to automatically exploit the vulnerability DNSChanger on home routers.
 <br>
 <strong>Author:</strong> Jhonathan Davi
 <script>commandLine('routerhunter');</script>


### PR DESCRIPTION
Routerhunter new url on github:
https://github.com/Exploit-install/Routerhunter-2.0